### PR TITLE
Feature/standard tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,103 @@
 # gembuild
-Set of generic scripts to standardize building of GEM DAQ software
-
-## Contents
-This repository contains various common definitions and templates for driving the build process.
+This package provides a set of generic scripts to standardize building of GEM DAQ software.
 
 ## Usage
 This repository should be checked out during a build, or added to the repository as a submodule at `REPO_BASE/config`
+Then, in the calling `Makefile`, the appropriate `include` should be made.
 
+## Contents
+This repository contains various common definitions and templates for driving the build process, as well as some scripts.
+
+### `tag2rel.sh`
+This script will extract automatically the version, build, and release information based on the `git` tag.
+For more information, execute `tag2rel.sh -h`
+
+### `make` helpers
+Targets that are defined within with a leading `_` are not intended to be used outside of the config package.a
+They should be neither overridden nor used as depndencies
+
+#### `mfCommonDefs.mk`
+Most common definitions needed, and basic targets.
+* Provides several common dependent directories with `?=` assignments, so they are easy to override elsewhere.
+* Sets several variables for metadata:
+  * `GEM_PLATFORM`: the development platform
+  * `GEM_OS`: the development operating system
+  * `GIT_VERSION`: the `git` version
+  * `GEMDEVELOPER`: the developer's name
+  * `GITREV`: the `git` short hash
+  * `BUILD_DATE`: the date
+  * `BUILD_VERSION`: will be used as the `Release`, and is extracted using `tag2rel.sh`
+  * `PREREL_VERSION`: will be used as part of the `pip` package name, and is extracted using `tag2rel.sh`
+* Package structure variables:
+  * `INSTALL_PATH` is the base directory of the installed project, defaults to `/opt/$(Project)`
+  * `ProjectPath` is the base directory of the project, defaults to `$(BUILD_HOME)/$(Project)`
+  * `PackagePath` is the base directory of the package, defaults to `$(ProjectPath)`
+  * `PackageIncludeDir`: location of the headers, defaults to `$(PackagePath)/include`
+  * `PackageSourceDir`: location of the source files, defaults to `$(PackagePath)/src`
+  * `PackageTestSourceDir`: location of source files to build into executables, defaults to `$(PackagePath)/test`
+  * `PackageLibraryDir`: location of library files, defaults to `$(PackagePath)/lib`
+  * `PackageExecDir`: location of executables, defaults to `$(PackagePath)/bin`
+  * `PackageObjectDir`: location of object files, defaults to `$(PackageSourceDir)/linux/$(Arch)`
+* Defines `default`, `clean`, `build`, `doc`, `all`, `install` and `uninstall` `make` targets
+  * `all` has a dependency on `build`
+* Provides `install` and `uninstall` `make` targets
+  * `install` depends on `all` and will copy all generated files to the expected installed package structure
+  * `uninstall` removes any files created during `install`
+
+#### `mfPythonDefs.mk`
+Additional definitions for `python` packages, and `python` package specific targets.
+
+* Provides `install-site` and `uninstall-site` `make` targets
+  * `install-site` depends on `rpmprep` and will copy all generated files to the expected installed package structure
+  * `uninstall-site` removes any files created during `install-site`
+
+#### `mfRPMRules.mk`
+Definitions needed to package into RPMs.
+Allows setting of required packages, as well as build required packages from a `packageinfo.h` file, located in `$(PackagePath)/include`
+* variables
+  * `RPM_DIR` directory where package RPM will be built, defaults to `$(PackagePath)/rpm`
+  * `RPMBUILD_DIR` the actual rpmbuild directory, defaults to `$(RPM_DIR)/RPMBUILD`
+* targets
+  * `rpmprep` should be defined to do any setup necessary between compiling and making the RPM, `rpm` depends on it
+  * `cleanrpm` removes `$(RPMBUILD_DIR)`, note that it does *not* remove the RPMs
+
+Defines `rpm` target, dependent on a `spec_update` target which fills the template spec file
+
+#### `mfPythonRPM.mk`
+Sets up environment and rules for packaging `python` packages.
+* variables
+  * `RPM_DIR` directory where package RPM will be built, defaults to `$(PackagePath)/rpm`
+  * `RPMBUILD_DIR` the actual rpmbuild directory, defaults to `$(RPM_DIR)/build`
+* targets
+  * `pip` creates a zip file, installable with `pip`
+  * `rpmprep` should be defined to do any setup necessary between compiling and making the RPM, `rpm` depends on it
+  * `cleanrpm` removes `$(RPMBUILD_DIR)`, note that it does *not* remove the RPMs
+  * `cleanallrpm` removes `$(RPM_DIR)`
+
+#### `mfSphinx.mk`
+Sets up the environment for building `sphinx` documentation and provides the necessary targets.
+
+#### `mfZynq.mk`
+Extra definitions for building on a Xilinx `Zynq` SoC
+
+* `CFLAGS`
+* `LDLIBS` set to include locations provided in the `PETA_STAGE`
+* `LDFLAGS` turns on `-g` by default, adds library locations from `LDLIBS`
+* `INSTALL_PATH` is changed to `/mnt/persistent/$(Project)`
+* Compiler toolchain is set to the `arm-linux-gnueabihf` toolchain, provided by the `Xilinx` SDK, with `:=` operator
+
+### Packaging templates
+#### `setupTemplate.cfg`
+A generic `setup.cfg` file for `python` packages.
+The values will be populated based on variables at the time the rule is executed.
+This file will be ignored if a package specific template already exists.
+
+#### `setupTemplate.py`
+A generic `setup.py` file for `python` packages.
+The values will be populated based on variables at the time the rule is executed.
+This file will be ignored if a package specific template already exists.
+
+#### `specTemplate.spec`
+A generic `spec` file for building RPM packages.
+The values will be populated based on variables at the time the rule is executed.
+This file will be ignored if a package specific template already exists.

--- a/mfCommonDefs.mk
+++ b/mfCommonDefs.mk
@@ -1,7 +1,9 @@
 BUILD_HOME ?= $(shell dirname `pwd`)
 $(info Using BUILD_HOME=$(BUILD_HOME))
 
-INSTALL_PREFIX?=/opt/$(Project)
+INSTALL_PATH=/opt/$(Project)
+
+ProjectPath = $(BUILD_HOME)/$(Project)
 
 # cmsgemos config. This section should be sourced from /opt/cmsgemos/config
 CMSGEMOS_ROOT?=/opt/cmsgemos
@@ -45,6 +47,7 @@ $(info OS Detected: $(GEM_OS))
 
 # Tools
 MakeDir=mkdir -p
+RM=rm -rf
 
 ## Version variables from Makefile and ShortPackage
 ShortPackageLoc:=$(shell echo "$(ShortPackage)" | tr '[:lower:]' '[:upper:]')
@@ -52,7 +55,8 @@ PACKAGE_VER_MAJOR?=$($(ShortPackageLoc)_VER_MAJOR)
 PACKAGE_VER_MINOR?=$($(ShortPackageLoc)_VER_MINOR)
 PACKAGE_VER_PATCH?=$($(ShortPackageLoc)_VER_PATCH)
 
-ConfigDir?=$(BUILD_HOME)/$(Project)/config
+ProjectBase?=$(BUILD_HOME)/$(Project)
+ConfigDir?=$(ProjectBase)/config
 
 BUILD_VERSION?=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[4];}' | awk '{split($$0,b,":"); print b[2];}')
 PREREL_VERSION?=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[8];}' | awk '{split($$0,b,":"); print b[2];}' )
@@ -60,8 +64,8 @@ PREREL_VERSION?=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print 
 $(info BUILD_VERSION $(BUILD_VERSION))
 $(info PREREL_VERSION $(PREREL_VERSION))
 
-CXX?=g++
-CC?=gcc
+CXX=g++
+CC=gcc
 
 PACKAGE_FULL_VERSION ?= $(PACKAGE_VER_MAJOR).$(PACKAGE_VER_MINOR).$(PACKAGE_VER_PATCH)
 PACKAGE_NOARCH_RELEASE ?= $(BUILD_VERSION).$(GITREV)git
@@ -69,3 +73,54 @@ PACKAGE_NOARCH_RELEASE ?= $(BUILD_VERSION).$(GITREV)git
 .PHONY: default all _all
 
 default:
+
+## Install should fail if the required variables are not set:
+# PackageLibraryDir, PackageIncludeDir, PackageExecDir, PackageSourceDir
+install: _all
+	echo "Executing install step"
+	$(MakeDir) $(INSTALL_PREFIX)$(INSTALL_PATH)/{bin,etc,include,lib,scripts}
+	if [ -d $(PackagePath)/lib ]; then \
+	   cd $(PackagePath)/lib; \
+	   find . -name "*.so" -exec install -D -m 755 {} $(INSTALL_PREFIX)$(INSTALL_PATH)/lib/{} \; ; \
+	fi
+#	   find . -type l -exec sh -c 'ln -s -f ${INSTALL_PREFIX}$(INSTALL_PATH)/lib/$(basename $(readlink $0)) ${INSTALL_PREFIX}${INSTALL_PATH}/lib/$0' {} \;
+
+	if [ -d $(PackagePath)/include ]; then \
+	   cd $(PackagePath)/include; \
+	   find . \( -name "*.h" -o -name "*.hh" -o -name "*.hpp" -o -name "*.hxx" \) \
+		-exec install -D -m 655 {} $(INSTALL_PREFIX)$(INSTALL_PATH)/include/{} \; ; \
+	fi
+
+	if [ -d $(PackagePath)/bin ]; then \
+	   cd $(PackagePath)/bin; \
+	   find . -name "*" -exec install -D -m 755 {} $(INSTALL_PREFIX)$(INSTALL_PATH)/bin/{} \; ; \
+	fi
+
+	if [ -d $(PackagePath)/etc ]; then \
+	   cd $(PackagePath)/etc; \
+	   find . -name "*" -exec install -D -m 644 {} $(INSTALL_PREFIX)$(INSTALL_PATH)/etc/{} \; ; \
+	fi
+
+	if [ -d $(PackagePath)/scripts ]; then \
+	   cd $(PackagePath)/scripts; \
+	   find . -name "*" -exec install -D -m 755 {} $(INSTALL_PREFIX)$(INSTALL_PATH)/scripts/{} \; ; \
+	fi
+
+	$(MakeDir) $(INSTALL_PREFIX)/usr/lib/debug$(INSTALL_PATH)/{bin,lib}
+	$(MakeDir) $(INSTALL_PREFIX)/usr/src/debug/$(Package)-$(PACKAGE_FULL_VERSION)
+
+	if [ -d $(PackagePath)/src ]; then \
+	   cd $(PackagePath)/src; \
+	   find . \( -name "*.cc"  -o -name "*.cpp" -o -name "*.cxx" -o -name "*.c" -o -name "*.C" \) \
+		-exec install -D -m 655 {} $(INSTALL_PREFIX)/usr/src/debug/$(Package)-$(PACKAGE_FULL_VERSION)/src/{} \; ; \
+	fi
+
+	touch MAINTAINER.md CHANGELOG.md README.md LICENSE
+
+uninstall:
+	$(RM) $(INSTALL_PREFIX)$(INSTALL_PATH)/{bin,etc,include,lib,scripts}
+	$(RM) $(INSTALL_PREFIX)/usr/lib/debug$(INSTALL_PATH)/{bin,lib}
+	$(RM) $(INSTALL_PREFIX)/usr/src/debug/$(Package)-$(PACKAGE_FULL_VERSION)
+	$(RM) $(INSTALL_PREFIX)$(INSTALL_PATH)/share/doc/$(Package)-$(PACKAGE_FULL_VERSION)
+#	$(RM) $(INSTALL_PREFIX)$(INSTALL_PATH)
+

--- a/mfPythonDefs.mk
+++ b/mfPythonDefs.mk
@@ -19,6 +19,7 @@ IncludeDirs+=$(PYTHON_INCLUDE_PREFIX)
 
 .PHONY: install-pip install-site uninstall-pip uninstall-site
 
+## @python-common install the python pip package
 install-pip: pip
 ifneq ($(or $(ThisIsAnEmptyVariable),$(RPM_DIR),$(PackageName),$(PACKAGE_FULL_VERSION),$(PREREL_VERSION)),)
 	pip install $(RPM_DIR)/$(PackageName)-$(PACKAGE_FULL_VERSION)$(PREREL_VERSION).zip
@@ -33,7 +34,7 @@ else
 #	$(error "Unable to run install-site due to unset variables")
 endif
 
-ifeq ($(and $(ThisIsAnEmptyVariable),$(Namespace),$(ShortPackage),$(INSTALL_PREFIX),$(PYTHON_SITE_PREFIX)),)
+ifeq ($(and $(ThisIsAnEmptyVariable),$(Namespace),$(ShortPackage),$(INSTALL_PREFIX),$(PYTHON_SITE_PREFIX),$(CMSGEMOS_ROOT)),)
 install-site uninstall-site: fail-pyinstall
 fail-pyinstall:
 	@echo "install-site require that certain arguments are set"
@@ -46,6 +47,7 @@ fail-pyinstall:
 #	$(error "Unable to run install-site due to unset variables")
 endif
 
+## @python-common install the python site-package
 install-site: _rpmprep
 ifneq ($(Arch),arm)
 	$(MakeDir) $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/$(Namespace)/$(ShortPackage)
@@ -53,14 +55,17 @@ ifneq ($(Arch),arm)
 	   cd pkg; \
 	   find $(Namespace) \( -type d -iname scripts \) -prune -o -type f \
 	       -exec install -D -m 755 {} $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/{} \; ; \
-	   find $(Namespace)/scripts -type f \
+	   cd $(Namespace)/scripts; \
+	   find . -type f \
 	       -exec install -D -m 755 {} $(INSTALL_PREFIX)$(CMSGEMOS_ROOT)/bin/$(ShortPackage)/{} \; ; \
 	fi
 endif
 
+## @python-common uninstall the python pip package
 uninstall-pip:
 	pip uninstall $(PackageName)
 
+## @python-common uninstall the python site-package
 uninstall-site:
 ifneq ($(Arch),arm)
 	$(RM) $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/$(Namespace)/$(ShortPackage)

--- a/mfPythonDefs.mk
+++ b/mfPythonDefs.mk
@@ -3,6 +3,7 @@ PYTHON_VERSION        = $(shell python -c "import distutils.sysconfig;print(dist
 # PYTHON_VERSION        = $(shell python -c "import sys; sys.stdout.write(sys.version[:3])")
 PYTHON_LIB            = python$(PYTHON_VERSION)
 PYTHON_LIB_PREFIX     = $(shell python -c "from distutils.sysconfig import get_python_lib;import os.path;print(os.path.split(get_python_lib(standard_lib=True))[0])")
+PYTHON_SITE_PREFIX    = $(shell python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 PYTHON_INCLUDE_PREFIX = $(shell python -c "import distutils.sysconfig;print(distutils.sysconfig.get_python_inc())")
 
 # Python Config
@@ -16,3 +17,24 @@ IncludeDirs+=$(PYTHON_INCLUDE_PREFIX)
 
 # DynamicLinkFlags+=
 
+.PHONY: install-pip install-site uninstall-pip uninstall-site
+install-pip: pip
+# reg_interface_gem-3.2.2-final.dev106.zip
+	pip install $(RPM_DIR)/$(PackageName)-$(PACKAGE_FULL_VERSION)$(PREREL_VERSION).zip
+
+install-site:
+ifneq ($(Arch),arm)
+	$(MakeDir) $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/$(Namespace)/$(ShortPackage)
+	@if [ -d pkg ]; then \
+	   cd pkg; \
+	   find $(Namespace) -type f -exec install -D -m 755 {} $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/$(Namespace)/$(ShortPackage)/{} \; ; \
+	fi
+endif
+
+uninstall-pip:
+	pip uninstall $(PackageName)
+
+uninstall-site:
+ifneq ($(Arch),arm)
+	$(RM) $(INSTALL_PREFIX)$(PYTHON_SITE_PREFIX)/$(Namespace)/$(ShortPackage)
+endif

--- a/mfPythonRPM.mk
+++ b/mfPythonRPM.mk
@@ -15,9 +15,12 @@ $(error Python module names missing "PythonModules")
 endif
 
 .PHONY: pip rpm rpmprep
+## @python-rpm Create a python package installable via pip
 pip: _sdistbuild _harvest
-
+## @python-rpm Create a python RPM package
 rpm: _rpmbuild _harvest
+## @python-rpm Perform any specific setup before packaging, is a dependency of both `pip` and `rpm`
+rpmprep:
 
 .PHONY: _sdistbuild _bdistbuild _sdistbuild
 .PHONY: _harvest _setup_update _rpmbuild _rpmsetup

--- a/mfRPMRules.mk
+++ b/mfRPMRules.mk
@@ -45,8 +45,11 @@ ifeq ($(Arch),arm)
 endif
 
 .PHONY: rpm rpmprep
+## @rpm performs all steps necessary to generate RPM packages
 rpm: _spec_update _rpmbuild _rpmharvest
-#rpm: _rpmharvest
+
+## @rpm Perform any specific setup before packaging, is an implicit dependency of `rpm`
+rpmprep:
 
 .PHONY: _rpmbuild _rpmharvest
 _rpmbuild: all _spec_update rpmprep
@@ -113,8 +116,10 @@ _spec_update:
 
 
 .PHONY: cleanrpm cleanallrpm
+## @rpm Clean up the rpm build directory
 cleanrpm:
 	$(RM) $(RPMBUILD_DIR)
 
-cleanallrpm:
+## @rpm Entirely remove the rpm directory
+cleanallrpm: cleanrpm
 	$(RM) $(RPM_DIR)

--- a/mfSphinx.mk
+++ b/mfSphinx.mk
@@ -4,8 +4,7 @@
 # You can set these variables from the command line.
 DOCBASE	      = doc
 SPHINXOPTS    =
-#SPHINXBUILD   = python $(shell which sphinx-build)
-SPHINXBUILD   = ~/.local/bin/sphinx-build #temporary hack
+SPHINXBUILD   = python $(shell which sphinx-build)
 PAPER         =
 SOURCEDIR     = $(DOCBASE)
 BUILDDIR      = $(DOCBASE)/_build

--- a/mfSphinx.mk
+++ b/mfSphinx.mk
@@ -16,64 +16,50 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(S
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 
-.PHONY: help cleandoc html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: cleandoc html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
-help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
-	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-
+## @sphinx Remove generated documentation directory
 cleandoc:
 	-rm -rf $(BUILDDIR)/*
 
+## @sphinx make standalone HTML files"
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+## @sphinx make HTML files named index.html in directories
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+## @sphinx make a single large HTML file
 singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
+## @sphinx make pickle files
 pickle:
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
+## @sphinx make JSON files
 json:
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
+## @sphinx make HTML files and a HTML help project
 htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
+## @sphinx make HTML files and a qthelp project
 qthelp:
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
@@ -83,6 +69,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/reg_utils.qhc"
 
+## @sphinx make HTML files and a Devhelp project
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
@@ -92,11 +79,13 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/reg_utils"
 	@echo "# devhelp"
 
+## @sphinx make an epub
 epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
+## @sphinx make LaTeX files, you can set PAPER=a4 or PAPER=letter
 latex:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
@@ -104,22 +93,26 @@ latex:
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
+## @sphinx make LaTeX files and run them through pdflatex
 latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
+## @sphinx make text files
 text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
+## @sphinx make man pages
 man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
+## @sphinx make Texinfo files
 texinfo:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
@@ -127,28 +120,33 @@ texinfo:
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
+## @sphinx make Texinfo files and run them through makeinfo
 info:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
+## @sphinx make PO message catalogs
 gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
+## @sphinx make an overview of all changed/added/deprecated items
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
+## @sphinx check all external links for integrity
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
+## @sphinx run all doctests embedded in the documentation (if enabled)
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \

--- a/mfZynq.mk
+++ b/mfZynq.mk
@@ -7,7 +7,7 @@ CFLAGS= -fomit-frame-pointer -pipe -fno-common -fno-builtin \
 	-march=armv7-a -mfpu=neon -mfloat-abi=hard \
 	-mthumb-interwork -mtune=cortex-a9 \
 	-DEMBED -Dlinux -D__linux__ -Dunix -fPIC \
-	--sysroot=$(PETA_STAGE)\
+	--sysroot=$(PETA_STAGE) \
 	-I$(PETA_STAGE)/usr/include \
 	-I$(PETA_STAGE)/include
 
@@ -15,10 +15,7 @@ LDLIBS= -L$(PETA_STAGE)/lib \
 	-L$(PETA_STAGE)/usr/lib \
 	-L$(PETA_STAGE)/ncurses
 
-LDFLAGS= -g \
-	-L$(PETA_STAGE)/lib \
-	-L$(PETA_STAGE)/usr/lib \
-	-L$(PETA_STAGE)/ncurses
+LDFLAGS= -g $(LDLIBS)
 
 INSTALL_PATH=/mnt/persistent/$(Project)
 

--- a/mfZynq.mk
+++ b/mfZynq.mk
@@ -15,11 +15,12 @@ LDLIBS= -L$(PETA_STAGE)/lib \
 	-L$(PETA_STAGE)/usr/lib \
 	-L$(PETA_STAGE)/ncurses
 
-LDFLAGS= -L$(PETA_STAGE)/lib \
+LDFLAGS= -g \
+	-L$(PETA_STAGE)/lib \
 	-L$(PETA_STAGE)/usr/lib \
 	-L$(PETA_STAGE)/ncurses
 
-INSTALL_PREFIX?=/mnt/persistent/$(Project)
+INSTALL_PATH=/mnt/persistent/$(Project)
 
 CXX:=arm-linux-gnueabihf-g++
 CC:=arm-linux-gnueabihf-gcc


### PR DESCRIPTION
* Adds a information to the `README`
* Adds a generic `help` target that is built based on the defined targets immediately preceeded by `## [@section] help message`
* Removes some redundant intermediary targets
* Adds common variables that can be overridden in package specific makefiles
* Adds `(un)install` targets for standard packages as well as two variants (`-pip`, and `-site`) for `python` packages

### testing
Tested against `xhal`, `ctp7_modules`, and `gem-plotting-tools`