### PR TITLE
[hotfix] no tag failure

### DIFF
--- a/tag2rel.sh
+++ b/tag2rel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh
 
 ## Script to extract versioning information from a git tag
 usage(){
@@ -79,6 +79,7 @@ gitrev=$(git rev-parse --short HEAD 2>/dev/null)
 gitver=$(git describe --abbrev=6 --dirty --always --tags 2>/dev/null)
 
 tagcommit=$(git rev-list --tags --max-count=1 2>/dev/null)
+
 if [ ! -n ${tagcommit+x} ]
 then
     lasttag=$(git describe --tags ${tagcommit} 2> /dev/null)


### PR DESCRIPTION
As reported in cms-gem-daq-project/reedmuller-c#3, the script was failing to correctly parse the git info if a tag was not present, when using an older version of `git`
This was due to the fact that the shebang was set to fail on error, although the underlying issue had been fixed in the past.
This PR changes the shebang to remove the fail on error such that if no tag is present, a version of `0.0.0` is assumed, and a release of `0.0.X`, where X is the number of commits since the initial commit, is made.

Additionally, updates to the `README` have been made to better describe some of the scripts and variables, as well as adding an example section for the local installation use case.
